### PR TITLE
Update how dependancies are determined

### DIFF
--- a/capistrano-chef.gemspec
+++ b/capistrano-chef.gemspec
@@ -19,5 +19,6 @@ Gem::Specification.new do |s|
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
-  s.requirements  = ['capistrano ~> 2.8.0', 'chef ~> 0.10.4']
+  s.add_dependency 'capistrano', '~> 2.8.0'
+  s.add_dependency 'chef', '~> 0.10.4'
 end

--- a/capistrano-chef.gemspec
+++ b/capistrano-chef.gemspec
@@ -4,7 +4,7 @@ require "capistrano/chef/version"
 
 Gem::Specification.new do |s|
   s.name        = "capistrano-chef"
-  s.version     = Capistrano::Chef::VERSION
+  s.version     = CapistranoChef::VERSION.dup
   s.platform    = Gem::Platform::RUBY
   s.license     = 'MIT'
   s.authors     = ['Nathan L Smith']

--- a/lib/capistrano/chef/version.rb
+++ b/lib/capistrano/chef/version.rb
@@ -1,5 +1,3 @@
-require 'capistrano' 
-
-class Capistrano::Chef
-  VERSION = '0.0.1'
+module CapistranoChef
+  VERSION = '0.0.1'.freeze
 end


### PR DESCRIPTION
I updated how the version is read and dependancies determined. Otherwise, I bundle threw errors if I didn't already have cap or chef installed.

This also makes sure that when installing capistrano-chef both capistrano and chef are installed if they user doesn't already have them.
