### PR TITLE
Fix for syntax errors under REE-1.8.7

### DIFF
--- a/lib/capistrano/chef.rb
+++ b/lib/capistrano/chef.rb
@@ -31,7 +31,7 @@ module Capistrano::Chef
     configuration.set :capistrano_chef, self
     configuration.load do
       def chef_role(name, query = '*:*', options = {})
-        role name, *capistrano_chef.search_chef_nodes(query), options
+        role name, *(capistrano_chef.search_chef_nodes(query) + [options])
       end
 
       def set_from_data_bag


### PR DESCRIPTION
Tested under MRI 1.8.7, REE-1.8.7, and 1.9.2. There were previous fixes for this issue in forks, however they were less elegant, and the forks were not based off of current master. 
