### PR TITLE
Make data_bag operations take an optional data_bag argument

### DIFF
--- a/lib/capistrano/chef.rb
+++ b/lib/capistrano/chef.rb
@@ -33,8 +33,8 @@ module Capistrano::Chef
     Chef::Search::Query.new.search(:node, query)[0].map(&search_proc)
   end
 
-  def self.get_apps_data_bag_item(id)
-    Chef::DataBagItem.load(:apps, id).raw_data
+  def self.get_apps_data_bag_item(id, databag=:apps)
+    Chef::DataBagItem.load(databag, id).raw_data
   end
 
   # Load into Capistrano
@@ -46,9 +46,9 @@ module Capistrano::Chef
         role name, *(capistrano_chef.search_chef_nodes(query, options.delete(:attribute)) + [options])
       end
 
-      def set_from_data_bag
+      def set_from_data_bag(databag=:apps)
         raise ':application must be set' if fetch(:application).nil?
-        capistrano_chef.get_apps_data_bag_item(application).each do |k, v|
+        capistrano_chef.get_apps_data_bag_item(application, databag).each do |k, v|
           set k, v
         end
       end


### PR DESCRIPTION
Instead of assuming that the databag for applications will be called :apps, this small patch defaults to apps and allows override.
