### PR TITLE
Minimum version, not fuzzy version

### DIFF
--- a/capistrano-chef.gemspec
+++ b/capistrano-chef.gemspec
@@ -20,5 +20,5 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
   s.add_dependency 'capistrano', '>= 2'
-  s.add_dependency 'chef', '~> 0.10.8'
+  s.add_dependency 'chef', '>= 0.10.8'
 end


### PR DESCRIPTION
Just a minor gemspec fix to un-pin from 0.10.x.  The minimum version is probably a better strategy until a new version of chef actually changes an API or something.
