### PR TITLE
Encrypted data bag support

### DIFF
--- a/capistrano-chef.gemspec
+++ b/capistrano-chef.gemspec
@@ -20,5 +20,5 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
   s.add_dependency 'capistrano', '>= 2'
-  s.add_dependency 'chef', '>= 0.10.8'
+  s.add_dependency 'chef', '>= 0.10.10'
 end

--- a/lib/capistrano/chef.rb
+++ b/lib/capistrano/chef.rb
@@ -37,6 +37,10 @@ module Capistrano::Chef
     Chef::DataBagItem.load(data_bag, id).raw_data
   end
 
+  def self.get_encrypted_data_bag_item(id, data_bag = :apps, secret = nil)
+    Chef::EncryptedDataBagItem.load(data_bag, id, secret).to_hash
+  end
+
   # Load into Capistrano
   def self.load_into(configuration)
     self.configure_chef
@@ -49,6 +53,13 @@ module Capistrano::Chef
       def set_from_data_bag(data_bag = :apps)
         raise ':application must be set' if fetch(:application).nil?
         capistrano_chef.get_data_bag_item(application, data_bag).each do |k, v|
+          set k, v
+        end
+      end
+
+      def set_from_encrypted_data_bag(data_bag = :apps, secret = nil)
+        raise ':application must be set' if fetch(:application).nil?
+        capistrano_chef.get_encrypted_data_bag_item(application, data_bag, secret).each do |k, v|
           set k, v
         end
       end


### PR DESCRIPTION
The API for encrypted data bags is almost the same as for regular ones. This does require a Chef minimum version of 0.10.10 however.
