### PR TITLE
Don't query chef when roles are being overridden by HOSTS environment variable

### DIFF
--- a/lib/capistrano/chef.rb
+++ b/lib/capistrano/chef.rb
@@ -48,7 +48,12 @@ module Capistrano::Chef
     configuration.load do
       def chef_role(name, query = '*:*', options = {})
         options = {:attribute => :ipaddress, :limit => 1000}.merge(options)
-        role name, *(capistrano_chef.search_chef_nodes(query, options.delete(:attribute), options.delete(:limit)) + [options])
+        # Don't do the lookup if HOSTS is used.
+        # Allows deployment from knifeless machine
+        # to specific hosts (ie. developent, staging)
+        unless ENV['HOSTS']
+          role name, *(capistrano_chef.search_chef_nodes(query, options.delete(:attribute), options.delete(:limit)) + [options])
+        end
       end
 
       def set_from_data_bag(data_bag = :apps)


### PR DESCRIPTION
When HOSTS environment variable is specified, roles gets overridden, so querying chef can be a waste of time.

Also, if the project is being deployed from a machine without knife configured. My use case is a chef client wants to clone to /tmp/project and deploy to itself with HOSTS=127.0.0.1. This allows deployment to not break due to knife not being configured.
