### PR TITLE
Support defining multiple Capistrano roles with the same host list

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ This defines the same roles using Chef's [search feature](http://wiki.opscode.co
 
 The `limit` attribute of the options hash will make it so only that the given number of items will be returned from a search.
 
+You can also define multiple roles at the same time if the host list is identical. Instead of running multiple searches to the Chef server, you can pass an Array to `chef_role`:
+
+    chef_role [:web, :app], 'roles:web', :attribute => Proc.new do |n|
+	  n["network"]["interfaces"]["eth1"]["addresses"].select{|address, data| data["family"] == "inet" }.keys.first
+	end
+
 ## Data Bags
 
 Chef [Data Bags](http://wiki.opscode.com/display/chef/Data+Bags) let you store arbitrary JSON data. A common pattern is to use an _apps_ data bag to store data about an application for use in configuration and deployment.

--- a/README.md
+++ b/README.md
@@ -44,9 +44,7 @@ The `limit` attribute of the options hash will make it so only that the given nu
 
 You can also define multiple roles at the same time if the host list is identical. Instead of running multiple searches to the Chef server, you can pass an Array to `chef_role`:
 
-    chef_role [:web, :app], 'roles:web', :attribute => Proc.new do |n|
-	  n["network"]["interfaces"]["eth1"]["addresses"].select{|address, data| data["family"] == "inet" }.keys.first
-	end
+    chef_role [:web, :app], 'roles:web'
 
 ## Data Bags
 

--- a/lib/capistrano/chef.rb
+++ b/lib/capistrano/chef.rb
@@ -52,7 +52,12 @@ module Capistrano::Chef
         # Allows deployment from knifeless machine
         # to specific hosts (ie. developent, staging)
         unless ENV['HOSTS']
-          role name, *(capistrano_chef.search_chef_nodes(query, options.delete(:attribute), options.delete(:limit)) + [options])
+          hosts = capistrano_chef.search_chef_nodes(query, options.delete(:attribute), options.delete(:limit)) + [options]
+          if name.is_a?(Array)
+            name.each { |n| role n, *hosts }
+          else
+            role name, *hosts
+          end
         end
       end
 

--- a/spec/capistrano/chef_spec.rb
+++ b/spec/capistrano/chef_spec.rb
@@ -140,6 +140,11 @@ describe Capistrano::Chef do
         @configuration.roles[:test].to_a[0].host.should === '10.0.0.2'
         @configuration.roles[:test2].to_a[0].host.should === '10.0.0.2'
       end
+
+      it 'does not call search more than once when defining multiple Cap roles' do
+        Capistrano::Chef.should_receive(:search_chef_nodes).once
+        @configuration.chef_role([:test, :test2])
+      end
     end
 
     it 'defaults to calling search with :ipaddress as the attribute and 1000 as the limit when giving a query' do

--- a/spec/capistrano/chef_spec.rb
+++ b/spec/capistrano/chef_spec.rb
@@ -120,14 +120,26 @@ describe Capistrano::Chef do
   end
 
   describe '#chef_role' do
-    it 'add nodes to the role' do
-      Capistrano::Chef.stub!(:search_chef_nodes).and_return(['10.0.0.2'])
-      @search = mock('Chef::Search::Query')
-      @configuration.should respond_to :chef_role
+    context 'when adding nodes to the role' do
+      before do
+        Capistrano::Chef.stub!(:search_chef_nodes).and_return(['10.0.0.2'])
+        @search = mock('Chef::Search::Query')
+        @configuration.should respond_to :chef_role
+      end
 
-      @configuration.chef_role(:test)
-      @configuration.roles.should have_key :test
-      @configuration.roles[:test].to_a[0].host.should === '10.0.0.2'
+      it 'add nodes to one role' do
+        @configuration.chef_role(:test)
+        @configuration.roles.should have_key :test
+        @configuration.roles[:test].to_a[0].host.should === '10.0.0.2'
+      end
+
+      it 'supports defining multiple roles in one go to avoid multiple searches' do
+        @configuration.chef_role([:test, :test2])
+        @configuration.roles.should have_key :test
+        @configuration.roles.should have_key :test2
+        @configuration.roles[:test].to_a[0].host.should === '10.0.0.2'
+        @configuration.roles[:test2].to_a[0].host.should === '10.0.0.2'
+      end
     end
 
     it 'defaults to calling search with :ipaddress as the attribute and 1000 as the limit when giving a query' do

--- a/spec/capistrano/chef_spec.rb
+++ b/spec/capistrano/chef_spec.rb
@@ -124,10 +124,10 @@ describe Capistrano::Chef do
       before do
         Capistrano::Chef.stub!(:search_chef_nodes).and_return(['10.0.0.2'])
         @search = mock('Chef::Search::Query')
-        @configuration.should respond_to :chef_role
       end
 
       it 'add nodes to one role' do
+        @configuration.should respond_to :chef_role
         @configuration.chef_role(:test)
         @configuration.roles.should have_key :test
         @configuration.roles[:test].to_a[0].host.should === '10.0.0.2'


### PR DESCRIPTION
This adds the ability to define multiple Capistrano roles with a single search when the host lists would be identical.  This is desirable when for example `:web` and `:app` are the same hosts in your environment.  It saves running the same Chef search multiple times with the same result.  Tests and README update included. 
