### PR TITLE
Preserve `attribute` key in options hash

### DIFF
--- a/lib/capistrano/dsl/chef.rb
+++ b/lib/capistrano/dsl/chef.rb
@@ -2,7 +2,7 @@ module Capistrano
   module DSL
     module Chef
       def chef_role(name, query = '*:*', options)
-        arg = options.delete(:attribute) || :ipaddress
+        arg = options.fetch(:attribute, :ipaddress)
 
         search_proc = case arg
                       when Proc


### PR DESCRIPTION
When passing the same `options` hash containing an `attribute` key to multiple invocations of `chef_role`, subsequent invocations would silently switch the attribute back to `:ipaddress` since `delete` was called on the hash.

The solution is to fetch the value instead, supplying a default of `:ipaddress` if it isn't defined.
