### PR TITLE
Fixed Syntax in Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ A normal `deploy.rb` in an app using capistrano defines a roles like this:
 Using capistrano-chef, you can do this:
 
     require 'capistrano/chef'
-    chef_role :web 'roles:web'
+    chef_role :web, 'roles:web'
     chef_role :db, 'roles:database_master', :primary   => true,
                                             :attribute => :private_ip,
                                             :limit     => 1


### PR DESCRIPTION
I updated the Readme documentation to include a ",".  This is needed in order to comply with the ruby syntax.
